### PR TITLE
Add cross-file capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
 	<div class="container">
 		<h3>What is LSIF?</h3>
 		<blockquote>
-            The Language Server Index Format (LSIF, pronounced “else if”) is a standard format for <a href="https://langserver.org">language 
-            servers</a> or other programming tools to emit their knowledge about a code workspace. This persisted information can 
+            The Language Server Index Format (LSIF, pronounced “else if”) is a standard format for <a href="https://langserver.org">language
+            servers</a> or other programming tools to emit their knowledge about a code workspace. This persisted information can
             later be used to answer LSP requests for the same workspace without running a language server.
 		</blockquote>
 		<p>
@@ -61,8 +61,8 @@
 		</p>
 		<p>
             LSIF is a standard format for persisted code analyzer output. It allows a code viewing client (e.g., an editor or code browser)
-             to provide features like autocomplete, go to definition, find references, and similar, without requiring a 
-             language analyzer to perform those computations in real-time. Today, several companies are working to support its growth, 
+             to provide features like autocomplete, go to definition, find references, and similar, without requiring a
+             language analyzer to perform those computations in real-time. Today, several companies are working to support its growth,
              including Sourcegraph and GitHub/Microsoft, and the protocol is beginning to be used to power a rapidly growing list
              of language intelligence tools.
             See below for details on and links to current indexer implementations.
@@ -72,13 +72,13 @@
 		<br/>
 		<h3>When is LSIF useful?</h3>
 		<p>
-            For many repositories, the only two build environments that understand the code well enough to provide code intelligence 
-            are your editor and CI. Most code browsers don’t have access to either of those environments, so they use heuristics to 
+            For many repositories, the only two build environments that understand the code well enough to provide code intelligence
+            are your editor and CI. Most code browsers don’t have access to either of those environments, so they use heuristics to
             provide code intelligence.
 		</p>
 		<p>
-            With LSIF, a build step in CI can dump information about the code to a file which can be transported anywhere. 
-            For example, code browsers only need that LSIF dump in order to provide hover tooltips, jump-to-definition, and 
+            With LSIF, a build step in CI can dump information about the code to a file which can be transported anywhere.
+            For example, code browsers only need that LSIF dump in order to provide hover tooltips, jump-to-definition, and
             find-references. This has many benefits:
             <ul>
                 <li>It’s fast because all of the information is precomputed</li>
@@ -130,7 +130,8 @@
 					<th>Hover documentation</th>
 					<th>Definitions</th>
 					<th>References</th>
-					<th>Monikers (for cross-project imports/exports)</th>
+					<th>Cross-file</th>
+					<th>Cross-repository</th>
 					<th>Additional capabilities</th>
 				</tr>
 			</thead>
@@ -138,6 +139,7 @@
 				<th>TypeScript</th>
 				<td><a href="https://microsoft.com/">Microsoft</a></td>
 				<td class="repo"><a href="https://github.com/microsoft/lsif-node/tree/master/tsc">https://github.com/microsoft/lsif-node/tree/master/tsc</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
@@ -152,6 +154,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td></td>
 			</tr>
             <tr>
@@ -159,6 +162,7 @@
 				<td><a href="https://sourcegraph.com/">Sourcegraph</a></td>
 				<td class="repo"><a href="https://github.com/sourcegraph/lsif-cpp">https://github.com/sourcegraph/lsif-cpp</a></td>
 				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
@@ -171,6 +175,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="warning"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="danger"></td>
 				<td></td>
 			</tr>
@@ -181,6 +186,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
 				<td class="danger"></td>
 				<td></td>
 			</tr>
@@ -195,6 +201,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="warning"></td>
+				<td class="warning"></td>
 				<td></td>
 			</tr>
             <tr>
@@ -204,6 +211,7 @@
 				<td class="danger"></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="warning"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="danger"></td>
 				<td></td>
 			</tr>


### PR DESCRIPTION
Sometimes it's easy to implement same-file but difficult to implement cross-file support, and not all LSIF indexers have cross-file support. It'd be helpful to measure progress by having a "Cross-file" column in the feature table.